### PR TITLE
Catch case in marker_table_to_matrix.

### DIFF
--- a/R/annotation.R
+++ b/R/annotation.R
@@ -36,6 +36,7 @@ marker_list_to_matrix = function(marker_list, known_genes, weighted=TRUE) {
     marker_list %>%
         tibble::enframe("cell_type", "gene") %>%
         tidyr::unnest(c("gene")) %>%
+        dplyr::mutate(group = "all") %>%
         marker_table_to_matrix(known_genes, weighted)
 }
 

--- a/R/visualization.R
+++ b/R/visualization.R
@@ -85,8 +85,10 @@ plot_assignments = function(assignments, umap_coordinates, enrichment_threshold 
     colnames(umap_coordinates) = c("umap_1", "umap_2")
     to_plot = assignments %>%
         dplyr::bind_cols(umap_coordinates) %>%
+        dplyr::mutate(predicted = as.character(.data$predicted)) %>%
         dplyr::mutate(predicted = ifelse(.data$enrichment < enrichment_threshold, NA, .data$predicted)) %>%
         dplyr::mutate(predicted = ifelse(.data$predicted == "unassigned", NA, .data$predicted))
+        dplyr::mutate(predicted = factor(.data$predicted))
     
     result = ggplot2::ggplot(to_plot, ggplot2::aes(x = .data$umap_1, y = .data$umap_2, col = .data$predicted))
     if (rasterize_umap) {

--- a/R/visualization.R
+++ b/R/visualization.R
@@ -85,8 +85,10 @@ plot_assignments = function(assignments, umap_coordinates, enrichment_threshold 
     colnames(umap_coordinates) = c("umap_1", "umap_2")
     to_plot = assignments %>%
         dplyr::bind_cols(umap_coordinates) %>%
+        dplyr::mutate(predicted = as.character(.data$predicted)) %>%
         dplyr::mutate(predicted = ifelse(.data$enrichment < enrichment_threshold, NA, .data$predicted)) %>%
-        dplyr::mutate(predicted = ifelse(.data$predicted == "unassigned", NA, .data$predicted))
+        dplyr::mutate(predicted = ifelse(.data$predicted == "unassigned", NA, .data$predicted)) %>%
+        dplyr::mutate(predicted = factor(.data$predicted))
     
     result = ggplot2::ggplot(to_plot, ggplot2::aes(x = .data$umap_1, y = .data$umap_2, col = .data$predicted))
     if (rasterize_umap) {

--- a/R/visualization.R
+++ b/R/visualization.R
@@ -87,7 +87,7 @@ plot_assignments = function(assignments, umap_coordinates, enrichment_threshold 
         dplyr::bind_cols(umap_coordinates) %>%
         dplyr::mutate(predicted = as.character(.data$predicted)) %>%
         dplyr::mutate(predicted = ifelse(.data$enrichment < enrichment_threshold, NA, .data$predicted)) %>%
-        dplyr::mutate(predicted = ifelse(.data$predicted == "unassigned", NA, .data$predicted))
+        dplyr::mutate(predicted = ifelse(.data$predicted == "unassigned", NA, .data$predicted)) %>%
         dplyr::mutate(predicted = factor(.data$predicted))
     
     result = ggplot2::ggplot(to_plot, ggplot2::aes(x = .data$umap_1, y = .data$umap_2, col = .data$predicted))

--- a/vignettes/HierarchicalAnnotation.Rmd
+++ b/vignettes/HierarchicalAnnotation.Rmd
@@ -147,7 +147,7 @@ All class assignments are relatively clear, we’ll proceed with predictions at 
 ```{r score_cell_types}
 top_markers = filter(ct_meta_markers[[test_dataset]], rank<=100)
 ct_scores = score_cells(log1p(cpm(datasets[[test_dataset]])), top_markers)
-head(ct_scores)
+ct_scores[1:6, 1:4]
 ```
 
 Note that scores encode group info, e.g. "endocrine|alpha".


### PR DESCRIPTION
### Catch case in marker_table_to_matrix.
marker_table_to_matrix() assumes a "group" column in the marker_table
argument. However, if the marker_set argument in score_cells is a list,
e.g. `marker_set = list(acinar = c("gene1", "gene2"),
                        ductal = c("gene3", "gene4"))`,
then the marker_table is generated by marker_list_to_matrix().
marker_list_to_matrix() only creates the "cell_type" and "gene"
columns. This commit adds the "group" column in marker_list_to_matrix().
Because the list version of marker_set does not support hierarchical
cell_types, this commit always labels all cells as "all" in the "group"
column.